### PR TITLE
Fix for PlexBMC extension

### DIFF
--- a/service.subtitles.betaseries/service.py
+++ b/service.subtitles.betaseries/service.py
@@ -62,12 +62,8 @@ def languageTranslate(lang, lang_from, lang_to):
 	
 def getShowId():
     try:
-      playerid_query = '{"jsonrpc": "2.0", "method": "Player.GetActivePlayers", "id": 1}'
-      playerid = json.loads(xbmc.executeJSONRPC(playerid_query))['result'][0]['playerid']
-      tvshowid_query = '{"jsonrpc": "2.0", "method": "Player.GetItem", "params": {"playerid": ' + str(playerid) + ', "properties": ["tvshowid"]}, "id": 1}'
-      tvshowid = json.loads(xbmc.executeJSONRPC (tvshowid_query))['result']['item']['tvshowid']
-      tvdbid_query = '{"jsonrpc": "2.0", "method": "VideoLibrary.GetTVShowDetails", "params": {"tvshowid": ' + str(tvshowid) + ', "properties": ["imdbnumber"]}, "id": 1}'
-      return json.loads(xbmc.executeJSONRPC (tvdbid_query))['result']['tvshowdetails']['imdbnumber']
+      searchurl = 'http://' + apiurl + '/shows/search?title=' + urllib.quote(item['tvshow']) + '&key=' + apikey
+      return str(json.load(urllib.urlopen(searchurl))['shows'][0]['thetvdb_id'])
     except:
       print "[SCRIPT] [EXCEPTION] BETASERIESSUBTITLES - no show id found"
 


### PR DESCRIPTION
When using an extension such as PleXBMC that only stream content and don't store anything on the current XBMC you dont have any tvshowid for the item you are watching.
So when you do this request `{"jsonrpc": "2.0", "method": "Player.GetItem", "params": {"playerid": ' + str(playerid) + ', "properties": ["tvshowid"]}, "id": 1}` the tvshowid resulting is -1.
And then GetTVShowDetails can't find any episode matching the request.
The error in the log is saying that `url` is not set (line 137) and the extension is throwing an error to the GUI.
To fix this kind of problem (streamed content with no tvshowid) I search the show with the BetaSeries API then I get the tvdb_id (instead of looking in XBMC metadata).
I've tested my code with complex TV show names and also show with different UK and US version, it has worked for all of them.
This fix has been test on Openelec 4.2 and XBMC 13.2.
