### PR TITLE
Add a check before deleting temp directory

### DIFF
--- a/service.subtitles.betaseries/service.py
+++ b/service.subtitles.betaseries/service.py
@@ -387,7 +387,7 @@ def search_subtitles(**search):
 
 # clean up
 log("deleting temp tree")
-shutil.rmtree(__temp__)
+if xbmcvfs.exists(__temp__):shutil.rmtree(__temp__)
 log("recreating temp dir")
 xbmcvfs.mkdirs(__temp__)
 


### PR DESCRIPTION
The 'rmtree' on temp directory fail on new install (folder doesn't exist).
Tested on :
- Fresh Kodi install : OK 
- Update from Xbmc : OK
