### PR TITLE
Update clean up temp dir

### DIFF
--- a/service.subtitles.betaseries/service.py
+++ b/service.subtitles.betaseries/service.py
@@ -405,7 +405,7 @@ def search_subtitles(search):
 # clean up
 if os.path.exists(__temp__):
     log("deleting temp tree...")
-    shutil.rmtree(__temp__)
+    shutil.rmtree(__temp__.encode("utf-8","ignore"))
 log("recreating temp dir...")
 xbmcvfs.mkdirs(__temp__)
 


### PR DESCRIPTION
Bonjour,

Je te soumet une petite modif proposé par bananabomb sur le wiki betaseries pour fiabiliser le clean up du repertoire temp.
Sans cela le service est planté chez moi des qu'il se retrouve avec des fichiers accentué dans le repertoire.
J'ai fait le patch sur ma version et cela semble bien fonctionner, donc autant le mettre dans la version officiel, d'autre doivent probablement être planté aussi.