### PR TITLE
Correction /episodes/watched : bulk=0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 update_repository.py
+/.vs

--- a/service.betaseries.com/betaseries.py
+++ b/service.betaseries.com/betaseries.py
@@ -217,6 +217,8 @@ class Main:
         urldata = {'v':self.apiver, 'key':service[2], 'token':service[6], 'thetvdb_id':episode[1]}
         if service[11]:
             urldata.update({'bulk': 1})
+        else
+            urldata.update({'bulk': 0})
         if episode[2] == 0:
             method = "DELETE"
             act = "not watched"

--- a/service.betaseries/betaseries.py
+++ b/service.betaseries/betaseries.py
@@ -205,6 +205,8 @@ class Main:
         urldata = {'v':self.apiver, 'key':service[2], 'token':service[6], 'thetvdb_id':episode[1]}
         if service[11]:
             urldata.update({'bulk': 1})
+        else
+            urldata.update({'bulk': 0})
         if episode[2] == 0:
             method = "DELETE"
             act = "not watched"


### PR DESCRIPTION
 Correction appel de l'API /episodes/watched. Le paramètre bulk de l'API est à 1 par défaut, donc il faut le passer explicitement quand il est à 0.